### PR TITLE
Add shell script extract_pics.sh and fix typos in two other scripts

### DIFF
--- a/Shell scripts/extract_pics.sh
+++ b/Shell scripts/extract_pics.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p pics
+for i in {3..134}
+do
+	./wolf3dextract -pic $i | ./vga2ppm --woven | convert /dev/stdin pics/pic_$i.png
+done

--- a/Shell scripts/extract_sprites.sh
+++ b/Shell scripts/extract_sprites.sh
@@ -3,5 +3,5 @@
 mkdir -p sprites
 for i in {0..435}
 do
-	./wolf3dextract -spr $i | ./vga2ppm -flipped | convert /dev/stdin sprites/sprite_$i.png
+	./wolf3dextract -spr $i | ./vga2ppm --flipped | convert /dev/stdin sprites/sprite_$i.png
 done

--- a/Shell scripts/extract_textures.sh
+++ b/Shell scripts/extract_textures.sh
@@ -3,5 +3,5 @@
 mkdir -p textures
 for i in {0..105}
 do
-	./wolf3dextract -tex $i | ./vga2ppm -transposed | convert /dev/stdin textures/texture_$i.png
+	./wolf3dextract -tex $i | ./vga2ppm --transposed | convert /dev/stdin textures/texture_$i.png
 done


### PR DESCRIPTION

1. Add new shell script `extract_pics.sh`
2. Fix typos in the scripts `extract_sprites.sh` and `extract_textures.sh`: vga2ppm expects the parameter to have two hyphens `--` instead of the one `-` that was specified in the original script

About `extract_pics.sh`: 

Nomen est omen: This script extracts all the pics using the `--woven` parameter for `vga2ppm`.

It works like a charm: Creates a `pics` folder and stores 132 PNG files there.

The script actually implements, what was described in [Issue #2](https://github.com/HiPhish/Wolf3DExtract/issues/2) of this repo.

Kown issues: The following pictures are scrambled: 9, 86, 87 and 89, I tried all the parameters of vga2ppm, but with no success. Anyway: The `extract_pics.sh` works fine and might improve the original repo, which is why I offer this pull request.